### PR TITLE
poc: custom ot for real-time editing

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -34,6 +34,7 @@
         "@types/express": "^5.0.0",
         "@types/express-session": "^1.18.0",
         "@types/express-sslify": "^1.2.5",
+        "@types/mocha": "^10.0.10",
         "@types/morgan": "^1.9.9",
         "@types/passport-google-oauth": "^1.0.45",
         "@types/passport-google-oauth20": "^2.0.16",
@@ -41,7 +42,9 @@
         "@types/pg-escape": "^0.2.3",
         "@types/uuid": "^10.0.0",
         "concurrently": "^9.1.2",
+        "mocha": "^11.7.5",
         "nodemon": "^3.1.9",
+        "ts-node": "^10.9.2",
         "typescript": "^5.6.3",
         "webpack": "^5.95.0",
         "webpack-cli": "^5.1.4",
@@ -52,6 +55,30 @@
         "node": "24.x"
       }
     },
+    "node_modules/@cspotcode/source-map-support": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",
+      "integrity": "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "0.3.9"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@cspotcode/source-map-support/node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz",
+      "integrity": "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.0.3",
+        "@jridgewell/sourcemap-codec": "^1.4.10"
+      }
+    },
     "node_modules/@discoveryjs/json-ext": {
       "version": "0.5.3",
       "resolved": "https://registry.npmjs.org/@discoveryjs/json-ext/-/json-ext-0.5.3.tgz",
@@ -59,6 +86,109 @@
       "dev": true,
       "engines": {
         "node": ">=10.0.0"
+      }
+    },
+    "node_modules/@isaacs/cliui": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
+      "integrity": "sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^5.1.2",
+        "string-width-cjs": "npm:string-width@^4.2.0",
+        "strip-ansi": "^7.0.1",
+        "strip-ansi-cjs": "npm:strip-ansi@^6.0.1",
+        "wrap-ansi": "^8.1.0",
+        "wrap-ansi-cjs": "npm:wrap-ansi@^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@isaacs/cliui/node_modules/ansi-regex": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+      "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "node_modules/@isaacs/cliui/node_modules/ansi-styles": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/@isaacs/cliui/node_modules/emoji-regex": {
+      "version": "9.2.2",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
+      "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@isaacs/cliui/node_modules/string-width": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz",
+      "integrity": "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "eastasianwidth": "^0.2.0",
+        "emoji-regex": "^9.2.2",
+        "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@isaacs/cliui/node_modules/strip-ansi": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.2.tgz",
+      "integrity": "sha512-gmBGslpoQJtgnMAvOVqGZpEz9dyoKTCzy2nfz/n8aIFhN/jCE/rCmcxabB6jOOHV+0WNnylOxaxBQPSvcWklhA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
+    "node_modules/@isaacs/cliui/node_modules/wrap-ansi": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-8.1.0.tgz",
+      "integrity": "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^6.1.0",
+        "string-width": "^5.0.1",
+        "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
       }
     },
     "node_modules/@jridgewell/gen-mapping": {
@@ -179,6 +309,17 @@
       "integrity": "sha512-Vo+PSpZG2/fmgmiNzYK9qWRh8h/CHrwD0mo1h1DzL4yzHNSfWYujGTYsWGreD000gcgmZ7K4Ys6Tx9TxtsKdDw==",
       "dev": true
     },
+    "node_modules/@pkgjs/parseargs": {
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
+      "integrity": "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=14"
+      }
+    },
     "node_modules/@prisma/client": {
       "version": "5.21.1",
       "resolved": "https://registry.npmjs.org/@prisma/client/-/client-5.21.1.tgz",
@@ -294,6 +435,34 @@
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/@socket.io/component-emitter/-/component-emitter-3.1.2.tgz",
       "integrity": "sha512-9BCxFwvbGg/RsZK9tjXd8s4UcwR0MWeFQ1XEKIQVVvAGJyINdrqKMcTRyLoK8Rse1GjzLV9cwjWV1olXRWEXVA=="
+    },
+    "node_modules/@tsconfig/node10": {
+      "version": "1.0.12",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.12.tgz",
+      "integrity": "sha512-UCYBaeFvM11aU2y3YPZ//O5Rhj+xKyzy7mvcIoAjASbigy8mHMryP5cK7dgjlz2hWxh1g5pLw084E0a/wlUSFQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@tsconfig/node12": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node12/-/node12-1.0.11.tgz",
+      "integrity": "sha512-cqefuRsh12pWyGsIoBKJA9luFu3mRxCA+ORZvA4ktLSzIuCUtWVxGIuXigEwO5/ywWFMZ2QEGKWvkZG1zDMTag==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@tsconfig/node14": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node14/-/node14-1.0.3.tgz",
+      "integrity": "sha512-ysT8mhdixWK6Hw3i1V2AeRqZ5WfXg1G43mqoYlM2nc6388Fq5jcXyr5mRsqViLx/GJYdoL0bfXD8nmF+Zn/Iow==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@tsconfig/node16": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.4.tgz",
+      "integrity": "sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/body-parser": {
       "version": "1.19.0",
@@ -421,6 +590,13 @@
       "integrity": "sha512-YATxVxgRqNH6nHEIsvg6k2Boc1JHI9ZbH5iWFFv/MTkchz3b1ieGDa5T0a9RznNdI0KhVbdbWSN+KWWrQZRxTw==",
       "dev": true
     },
+    "node_modules/@types/mocha": {
+      "version": "10.0.10",
+      "resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-10.0.10.tgz",
+      "integrity": "sha512-xPyYSz1cMPnJQhl0CLMH68j3gprKZaTjG3s5Vi+fDgx+uhG9NOXwbVt52eFS8ECyXhyKcjDLCBEqBExKuiZb7Q==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/morgan": {
       "version": "1.9.9",
       "resolved": "https://registry.npmjs.org/@types/morgan/-/morgan-1.9.9.tgz",
@@ -434,6 +610,7 @@
       "version": "22.7.6",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-22.7.6.tgz",
       "integrity": "sha512-/d7Rnj0/ExXDMcioS78/kf1lMzYk4BZV8MZGTBKzTGZ6/406ukkbYlIsZmMPhcR5KlkunDHQLrtAVmSq7r+mSw==",
+      "peer": true,
       "dependencies": {
         "undici-types": "~6.19.2"
       }
@@ -879,6 +1056,19 @@
         "acorn": "^8"
       }
     },
+    "node_modules/acorn-walk": {
+      "version": "8.3.4",
+      "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.3.4.tgz",
+      "integrity": "sha512-ueEepnujpqee2o5aIYnvHU6C0A42MNdsIDeqy5BydrkuC5R1ZuUFnm27EeFJGoEHJQgn3uleRvmTXaJgfXbt4g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "acorn": "^8.11.0"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
     "node_modules/ajv": {
       "version": "6.12.6",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
@@ -994,6 +1184,20 @@
       "engines": {
         "node": ">= 8"
       }
+    },
+    "node_modules/arg": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
+      "integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/argparse": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+      "dev": true,
+      "license": "Python-2.0"
     },
     "node_modules/array-flatten": {
       "version": "1.1.1",
@@ -1140,6 +1344,13 @@
         "node": ">=8"
       }
     },
+    "node_modules/browser-stdout": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.1.tgz",
+      "integrity": "sha512-qhAVI1+Av2X7qelOfAIYwXONood6XlZE/fXaBSmW/T5SzLAmCgzi+eiWE7fUvbHaeNBQH13UftjpXxsfLkMpgw==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/browserslist": {
       "version": "4.24.0",
       "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.24.0.tgz",
@@ -1218,6 +1429,19 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/camelcase": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.3.0.tgz",
+      "integrity": "sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/caniuse-lite": {
@@ -1547,11 +1771,19 @@
         "node": ">= 0.10"
       }
     },
-    "node_modules/cross-spawn": {
-      "version": "7.0.3",
-      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
-      "integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
+    "node_modules/create-require": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
+      "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "dev": true,
+      "license": "MIT",
       "dependencies": {
         "path-key": "^3.1.0",
         "shebang-command": "^2.0.0",
@@ -1575,6 +1807,19 @@
         "supports-color": {
           "optional": true
         }
+      }
+    },
+    "node_modules/decamelize": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-4.0.0.tgz",
+      "integrity": "sha512-9iE1PgSik9HeIIw2JO94IidnE3eBoQrFJ3w7sFuzSX4DpmZ3v5sZpUiV5Swcf6mQEF+Y0ru8Neo+p+nyh2J+hQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/default-browser": {
@@ -1657,6 +1902,16 @@
       "integrity": "sha512-T0NIuQpnTvFDATNuHN5roPwSBG83rFsuO+MXXH9/3N1eFbn4wcPjttvjMLEPWJ0RGUYgQE7cGgS3tNxbqCGM7g==",
       "dev": true
     },
+    "node_modules/diff": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
+      "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.3.1"
+      }
+    },
     "node_modules/dns-packet": {
       "version": "5.6.1",
       "resolved": "https://registry.npmjs.org/dns-packet/-/dns-packet-5.6.1.tgz",
@@ -1679,6 +1934,13 @@
       "funding": {
         "url": "https://dotenvx.com"
       }
+    },
+    "node_modules/eastasianwidth": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
+      "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/ee-first": {
       "version": "1.1.1",
@@ -1857,6 +2119,19 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
       "integrity": "sha1-Aljq5NPQwJdN4cFpGI7wBR0dGYg="
+    },
+    "node_modules/escape-string-regexp": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+      "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/eslint-scope": {
       "version": "5.1.1",
@@ -2222,6 +2497,16 @@
         "node": ">=8"
       }
     },
+    "node_modules/flat": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/flat/-/flat-5.0.2.tgz",
+      "integrity": "sha512-b6suED+5/3rTpUBdG1gupIl8MPFCAMA0QXwmljLhvCUKcUvdE4gWky9zpuGCcXHOsz4J9wPGNWq6OKpmIzz3hQ==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "bin": {
+        "flat": "cli.js"
+      }
+    },
     "node_modules/follow-redirects": {
       "version": "1.15.9",
       "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.9.tgz",
@@ -2240,6 +2525,23 @@
         "debug": {
           "optional": true
         }
+      }
+    },
+    "node_modules/foreground-child": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.1.tgz",
+      "integrity": "sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "cross-spawn": "^7.0.6",
+        "signal-exit": "^4.0.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/forwarded": {
@@ -2315,6 +2617,27 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/glob": {
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-10.5.0.tgz",
+      "integrity": "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "foreground-child": "^3.1.0",
+        "jackspeak": "^3.1.2",
+        "minimatch": "^9.0.4",
+        "minipass": "^7.1.2",
+        "package-json-from-dist": "^1.0.0",
+        "path-scurry": "^1.11.1"
+      },
+      "bin": {
+        "glob": "dist/esm/bin.mjs"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/glob-parent": {
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
@@ -2332,6 +2655,32 @@
       "resolved": "https://registry.npmjs.org/glob-to-regexp/-/glob-to-regexp-0.4.1.tgz",
       "integrity": "sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw==",
       "dev": true
+    },
+    "node_modules/glob/node_modules/brace-expansion": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
+      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/glob/node_modules/minimatch": {
+      "version": "9.0.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
+      "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
     },
     "node_modules/gopd": {
       "version": "1.0.1",
@@ -2407,6 +2756,16 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/he": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/he/-/he-1.2.0.tgz",
+      "integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "he": "bin/he"
       }
     },
     "node_modules/hpack.js": {
@@ -2705,6 +3064,16 @@
         "node": ">=0.12.0"
       }
     },
+    "node_modules/is-path-inside": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-3.0.3.tgz",
+      "integrity": "sha512-Fd4gABb+ycGAmKou8eMftCupSir5lRxqf4aD/vd0cD2qc4HL07OjCeuHMr8Ro4CoMaeCKDB0/ECBOVWjTwUvPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/is-plain-obj": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-3.0.0.tgz",
@@ -2727,6 +3096,19 @@
       },
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-unicode-supported": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-0.1.0.tgz",
+      "integrity": "sha512-knxG2q4UC3u8stRGyAVJCOdxFmv5DZiRcdlIaAQXAbSfJya+OhopNotLQrstBhququ4ZpuKbDc/8S6mgXgPFPw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/is-wsl": {
@@ -2765,6 +3147,22 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/jackspeak": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-3.4.3.tgz",
+      "integrity": "sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "@isaacs/cliui": "^8.0.2"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      },
+      "optionalDependencies": {
+        "@pkgjs/parseargs": "^0.11.0"
+      }
+    },
     "node_modules/jest-worker": {
       "version": "27.5.1",
       "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-27.5.1.tgz",
@@ -2777,6 +3175,19 @@
       },
       "engines": {
         "node": ">= 10.13.0"
+      }
+    },
+    "node_modules/js-yaml": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
+      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^2.0.1"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
       }
     },
     "node_modules/json-parse-even-better-errors": {
@@ -2830,6 +3241,37 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/log-symbols": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-4.1.0.tgz",
+      "integrity": "sha512-8XPvpAA8uyhfteu8pIvQxpJZ7SYYdpUivZpGy6sFsBuKRY/7rQGavedeB8aK+Zkyq6upMFVL/9AW6vOYzfRyLg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "^4.1.0",
+        "is-unicode-supported": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/lru-cache": {
+      "version": "10.4.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/make-error": {
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
+      "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/media-typer": {
       "version": "0.3.0",
@@ -2940,6 +3382,184 @@
       },
       "engines": {
         "node": "*"
+      }
+    },
+    "node_modules/minipass": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.2.tgz",
+      "integrity": "sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      }
+    },
+    "node_modules/mocha": {
+      "version": "11.7.5",
+      "resolved": "https://registry.npmjs.org/mocha/-/mocha-11.7.5.tgz",
+      "integrity": "sha512-mTT6RgopEYABzXWFx+GcJ+ZQ32kp4fMf0xvpZIIfSq9Z8lC/++MtcCnQ9t5FP2veYEP95FIYSvW+U9fV4xrlig==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "browser-stdout": "^1.3.1",
+        "chokidar": "^4.0.1",
+        "debug": "^4.3.5",
+        "diff": "^7.0.0",
+        "escape-string-regexp": "^4.0.0",
+        "find-up": "^5.0.0",
+        "glob": "^10.4.5",
+        "he": "^1.2.0",
+        "is-path-inside": "^3.0.3",
+        "js-yaml": "^4.1.0",
+        "log-symbols": "^4.1.0",
+        "minimatch": "^9.0.5",
+        "ms": "^2.1.3",
+        "picocolors": "^1.1.1",
+        "serialize-javascript": "^6.0.2",
+        "strip-json-comments": "^3.1.1",
+        "supports-color": "^8.1.1",
+        "workerpool": "^9.2.0",
+        "yargs": "^17.7.2",
+        "yargs-parser": "^21.1.1",
+        "yargs-unparser": "^2.0.0"
+      },
+      "bin": {
+        "_mocha": "bin/_mocha",
+        "mocha": "bin/mocha.js"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/mocha/node_modules/brace-expansion": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
+      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/mocha/node_modules/chokidar": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-4.0.3.tgz",
+      "integrity": "sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "readdirp": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 14.16.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/mocha/node_modules/diff": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-7.0.0.tgz",
+      "integrity": "sha512-PJWHUb1RFevKCwaFA9RlG5tCd+FO5iRh9A8HEtkmBH2Li03iJriB6m6JIN4rGz3K3JLawI7/veA1xzRKP6ISBw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.3.1"
+      }
+    },
+    "node_modules/mocha/node_modules/find-up": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
+      "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "locate-path": "^6.0.0",
+        "path-exists": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/mocha/node_modules/locate-path": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
+      "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-locate": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/mocha/node_modules/minimatch": {
+      "version": "9.0.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
+      "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/mocha/node_modules/p-limit": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
+      "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "yocto-queue": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/mocha/node_modules/p-locate": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
+      "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-limit": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/mocha/node_modules/readdirp": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-4.1.2.tgz",
+      "integrity": "sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14.18.0"
+      },
+      "funding": {
+        "type": "individual",
+        "url": "https://paulmillr.com/funding/"
       }
     },
     "node_modules/morgan": {
@@ -3206,6 +3826,13 @@
         "node": ">=6"
       }
     },
+    "node_modules/package-json-from-dist": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
+      "integrity": "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==",
+      "dev": true,
+      "license": "BlueOak-1.0.0"
+    },
     "node_modules/parseurl": {
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
@@ -3321,6 +3948,23 @@
       "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
       "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
       "dev": true
+    },
+    "node_modules/path-scurry": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.11.1.tgz",
+      "integrity": "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "lru-cache": "^10.2.0",
+        "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
     },
     "node_modules/path-to-regexp": {
       "version": "0.1.10",
@@ -4036,6 +4680,19 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/signal-exit": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/simple-update-notifier": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/simple-update-notifier/-/simple-update-notifier-2.0.0.tgz",
@@ -4249,6 +4906,22 @@
         "node": ">=8"
       }
     },
+    "node_modules/string-width-cjs": {
+      "name": "string-width",
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/strip-ansi": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
@@ -4260,6 +4933,33 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi-cjs": {
+      "name": "strip-ansi",
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-json-comments": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
+      "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/supports-color": {
@@ -4424,6 +5124,50 @@
         "tree-kill": "cli.js"
       }
     },
+    "node_modules/ts-node": {
+      "version": "10.9.2",
+      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.9.2.tgz",
+      "integrity": "sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@cspotcode/source-map-support": "^0.8.0",
+        "@tsconfig/node10": "^1.0.7",
+        "@tsconfig/node12": "^1.0.7",
+        "@tsconfig/node14": "^1.0.0",
+        "@tsconfig/node16": "^1.0.2",
+        "acorn": "^8.4.1",
+        "acorn-walk": "^8.1.1",
+        "arg": "^4.1.0",
+        "create-require": "^1.1.0",
+        "diff": "^4.0.1",
+        "make-error": "^1.1.1",
+        "v8-compile-cache-lib": "^3.0.1",
+        "yn": "3.1.1"
+      },
+      "bin": {
+        "ts-node": "dist/bin.js",
+        "ts-node-cwd": "dist/bin-cwd.js",
+        "ts-node-esm": "dist/bin-esm.js",
+        "ts-node-script": "dist/bin-script.js",
+        "ts-node-transpile-only": "dist/bin-transpile.js",
+        "ts-script": "dist/bin-script-deprecated.js"
+      },
+      "peerDependencies": {
+        "@swc/core": ">=1.2.50",
+        "@swc/wasm": ">=1.2.50",
+        "@types/node": "*",
+        "typescript": ">=2.7"
+      },
+      "peerDependenciesMeta": {
+        "@swc/core": {
+          "optional": true
+        },
+        "@swc/wasm": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/tslib": {
       "version": "2.8.0",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.0.tgz",
@@ -4448,6 +5192,7 @@
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.6.3.tgz",
       "integrity": "sha512-hjcS1mhfuyi4WW8IWtjP7brDrG2cuDZukyrYrSauoXGNgx0S7zceP07adYkJycEr56BOUTNPzbInooiN3fn1qw==",
       "dev": true,
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -4555,6 +5300,13 @@
       "bin": {
         "uuid": "dist/bin/uuid"
       }
+    },
+    "node_modules/v8-compile-cache-lib": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz",
+      "integrity": "sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/vary": {
       "version": "1.1.2",
@@ -5027,7 +5779,33 @@
       "integrity": "sha512-JcKqAHLPxcdb9KM49dufGXn2x3ssnfjbcaQdLlfZsL9rH9wgDQjUtDxbo8NE0F6SFvydeu1VhZe7hZuHsB2/pw==",
       "dev": true
     },
+    "node_modules/workerpool": {
+      "version": "9.3.4",
+      "resolved": "https://registry.npmjs.org/workerpool/-/workerpool-9.3.4.tgz",
+      "integrity": "sha512-TmPRQYYSAnnDiEB0P/Ytip7bFGvqnSU6I2BcuSw7Hx+JSg/DsUi5ebYfc8GYaSdpuvOcEs6dXxPurOYpe9QFwg==",
+      "dev": true,
+      "license": "Apache-2.0"
+    },
     "node_modules/wrap-ansi": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi-cjs": {
+      "name": "wrap-ansi",
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
       "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
@@ -5123,6 +5901,55 @@
       "license": "ISC",
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/yargs-unparser": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/yargs-unparser/-/yargs-unparser-2.0.0.tgz",
+      "integrity": "sha512-7pRTIA9Qc1caZ0bZ6RYRGbHJthJWuakf+WmHK0rVeLkNrrGhfoabBNdue6kdINI6r4if7ocq9aD/n7xwKOdzOA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "camelcase": "^6.0.0",
+        "decamelize": "^4.0.0",
+        "flat": "^5.0.2",
+        "is-plain-obj": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/yargs-unparser/node_modules/is-plain-obj": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-2.1.0.tgz",
+      "integrity": "sha512-YWnfyRwxL/+SsrWYfOpUtz5b3YD+nyfkHvjbcanzk8zgyO4ASD67uVMRt8k5bM4lLMDnXfriRhOpemw+NfT1eA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/yn": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
+      "integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/yocto-queue": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
+      "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     }
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -49,7 +49,7 @@
         "webpack-node-externals": "^3.0.0"
       },
       "engines": {
-        "node": "21.7.1"
+        "node": "24.x"
       }
     },
     "node_modules/@discoveryjs/json-ext": {

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "dev-hot": "prisma generate && concurrently \"tsc --watch\" \"webpack --watch\" \"nodemon --watch build build/start.js\"",
     "heroku-postbuild": "npm run build && npm run migrate",
     "migrate": "prisma migrate deploy",
-    "test": "echo \"Error: no test specified\" && exit 1",
+    "test": "npm run build && mocha -r ts-node/register src/server/ot.test.ts src/server/ot-integration.test.ts",
     "up": "docker compose -f docker-compose.yml -f docker-compose.dev.yml up"
   },
   "repository": {
@@ -52,6 +52,7 @@
     "@types/express": "^5.0.0",
     "@types/express-session": "^1.18.0",
     "@types/express-sslify": "^1.2.5",
+    "@types/mocha": "^10.0.10",
     "@types/morgan": "^1.9.9",
     "@types/passport-google-oauth": "^1.0.45",
     "@types/passport-google-oauth20": "^2.0.16",
@@ -59,7 +60,9 @@
     "@types/pg-escape": "^0.2.3",
     "@types/uuid": "^10.0.0",
     "concurrently": "^9.1.2",
+    "mocha": "^11.7.5",
     "nodemon": "^3.1.9",
+    "ts-node": "^10.9.2",
     "typescript": "^5.6.3",
     "webpack": "^5.95.0",
     "webpack-cli": "^5.1.4",

--- a/src/client/assets/js/ot-client.ts
+++ b/src/client/assets/js/ot-client.ts
@@ -1,0 +1,124 @@
+// Client-side OT utilities
+import { TextOp, apply, transform, simpleDiff, transformPosition } from "../../../server/ot.js";
+
+export interface PendingOp {
+  opId: string;
+  op: TextOp;
+  baseVersion: number;
+}
+
+export interface ClientOTState {
+  docId: string;
+  confirmedVersion: number;
+  confirmedText: string;
+  outbox: PendingOp[];
+}
+
+let opCounter = 0;
+
+export function generateOpId(): string {
+  return `client-${Date.now()}-${opCounter++}`;
+}
+
+export function createInitialState(docId: string, initialText: string, initialVersion: number): ClientOTState {
+  return {
+    docId,
+    confirmedVersion: initialVersion,
+    confirmedText: initialText,
+    outbox: [],
+  };
+}
+
+export function handleLocalEdit(
+  state: ClientOTState,
+  oldText: string,
+  newText: string
+): { state: ClientOTState; pendingOp: PendingOp } {
+  // Compute diff
+  const op = simpleDiff(oldText, newText);
+
+  // Base version should account for pending ops
+  // If we have pending ops, this new op is based on those ops being applied
+  const baseVersion = state.confirmedVersion + state.outbox.length;
+
+  // Create pending op
+  const pendingOp: PendingOp = {
+    opId: generateOpId(),
+    op,
+    baseVersion,
+  };
+
+  // Add to outbox
+  const newOutbox = [...state.outbox, pendingOp];
+
+  return {
+    state: { ...state, outbox: newOutbox },
+    pendingOp,
+  };
+}
+
+export function handleServerOp(
+  state: ClientOTState,
+  serverOp: TextOp,
+  serverVersion: number,
+  serverOpId?: string
+): { state: ClientOTState; localText: string; isOwnOp: boolean } {
+  // Check if this is our own op
+  const ourOpIndex = state.outbox.findIndex(p => p.opId === serverOpId);
+
+  if (ourOpIndex !== -1) {
+    // OUR OP - Server acknowledged it
+    // Remove from outbox
+    const newOutbox = state.outbox.filter((_, i) => i !== ourOpIndex);
+
+    // Apply server's version to confirmed state
+    const newConfirmedText = apply(serverOp, state.confirmedText);
+
+    // Recompute local text from confirmed + remaining outbox
+    let localText = newConfirmedText;
+    for (const pending of newOutbox) {
+      localText = apply(pending.op, localText);
+    }
+
+    return {
+      state: {
+        ...state,
+        confirmedText: newConfirmedText,
+        confirmedVersion: serverVersion,
+        outbox: newOutbox,
+      },
+      localText,
+      isOwnOp: true,
+    };
+  } else {
+    // REMOTE OP - Another client's edit
+    // Apply to confirmed state
+    const newConfirmedText = apply(serverOp, state.confirmedText);
+
+    // Transform all pending ops in outbox against this remote op
+    const newOutbox = state.outbox.map(pending => ({
+      ...pending,
+      op: transform(pending.op, serverOp),
+    }));
+
+    // Recompute local text
+    let localText = newConfirmedText;
+    for (const pending of newOutbox) {
+      localText = apply(pending.op, localText);
+    }
+
+    return {
+      state: {
+        ...state,
+        confirmedText: newConfirmedText,
+        confirmedVersion: serverVersion,
+        outbox: newOutbox,
+      },
+      localText,
+      isOwnOp: false,
+    };
+  }
+}
+
+// Re-export OT utilities for convenience
+export { TextOp, apply, transform, simpleDiff, transformPosition };

--- a/src/server/ot-integration.test.ts
+++ b/src/server/ot-integration.test.ts
@@ -1,0 +1,153 @@
+import { Document } from "./document";
+import { TextOp, apply, simpleDiff } from "./ot";
+import assert from "assert";
+
+describe("OT Integration Tests", () => {
+  describe("Single Client Basic Operations", () => {
+    it("should handle single character insertion from empty", () => {
+      const doc = new Document("test", "", 0, new Date());
+
+      // Simulate client typing "a"
+      const op: TextOp = [{ insert: "a" }];
+      const result = doc.applyOp(op, 0);
+
+      console.log("Op:", JSON.stringify(op));
+      console.log("Result content:", doc.content);
+      console.log("Result version:", doc.version);
+
+      assert.strictEqual(doc.content, "a");
+      assert.strictEqual(doc.version, 1);
+    });
+
+    it("should handle sequential character insertions", () => {
+      const doc = new Document("test", "", 0, new Date());
+
+      // Type "a"
+      const op1: TextOp = [{ insert: "a" }];
+      doc.applyOp(op1, 0);
+      console.log("After 'a':", doc.content, "v" + doc.version);
+      assert.strictEqual(doc.content, "a");
+
+      // Type "b" (at end)
+      const op2: TextOp = [{ retain: 1 }, { insert: "b" }];
+      doc.applyOp(op2, 1);
+      console.log("After 'b':", doc.content, "v" + doc.version);
+      assert.strictEqual(doc.content, "ab");
+
+      // Type "c" (at end)
+      const op3: TextOp = [{ retain: 2 }, { insert: "c" }];
+      doc.applyOp(op3, 2);
+      console.log("After 'c':", doc.content, "v" + doc.version);
+      assert.strictEqual(doc.content, "abc");
+    });
+
+    it("should handle rapid typing with simpleDiff", () => {
+      const doc = new Document("test", "", 0, new Date());
+
+      const sequence = ["a", "ab", "abc", "abcd", "abcde"];
+      let prevText = "";
+
+      for (let i = 0; i < sequence.length; i++) {
+        const newText = sequence[i];
+        const op = simpleDiff(prevText, newText);
+
+        console.log(`\nStep ${i + 1}: "${prevText}" -> "${newText}"`);
+        console.log("  Op:", JSON.stringify(op));
+        console.log("  Base version:", doc.version);
+
+        const result = doc.applyOp(op, doc.version);
+
+        console.log("  Result:", doc.content);
+        console.log("  New version:", doc.version);
+
+        assert.strictEqual(doc.content, newText);
+        prevText = newText;
+      }
+
+      assert.strictEqual(doc.content, "abcde");
+      assert.strictEqual(doc.version, 5);
+    });
+
+    it("should detect the bug: ops based on wrong version", () => {
+      const doc = new Document("test", "", 0, new Date());
+
+      // This simulates what the client was doing wrong:
+      // All ops based on version 0, but with different base texts
+
+      const op1 = simpleDiff("", "a");
+      console.log("\nOp 1 ('' -> 'a'):", JSON.stringify(op1));
+      doc.applyOp(op1, 0);
+      console.log("After op1:", doc.content, "v" + doc.version);
+
+      // BUG: This op is based on version 0, but computes diff from "a" -> "aa"
+      // It should be based on version 1!
+      const op2 = simpleDiff("a", "aa");
+      console.log("\nOp 2 ('a' -> 'aa', but claiming base v0):", JSON.stringify(op2));
+      console.log("Server doc is:", doc.content, "v" + doc.version);
+
+      try {
+        doc.applyOp(op2, 0); // This should fail!
+        console.log("After op2:", doc.content);
+        assert.fail("Should have thrown an error");
+      } catch (e: any) {
+        console.log("Expected error:", e.message);
+        assert.ok(e.message.includes("Retain"));
+      }
+    });
+  });
+
+  describe("Concurrent Edits", () => {
+    it("should handle two concurrent inserts at end", () => {
+      const doc = new Document("test", "hello", 0, new Date());
+
+      // Client 1: insert " world" at end (based on v0)
+      const op1 = simpleDiff("hello", "hello world");
+      console.log("Client 1 op:", JSON.stringify(op1));
+
+      // Client 2: insert "!" at end (based on v0, concurrent)
+      const op2 = simpleDiff("hello", "hello!");
+      console.log("Client 2 op:", JSON.stringify(op2));
+
+      // Server receives op1 first
+      doc.applyOp(op1, 0);
+      console.log("After client 1:", doc.content, "v" + doc.version);
+      assert.strictEqual(doc.content, "hello world");
+
+      // Server receives op2 (needs transformation against op1)
+      const result2 = doc.applyOp(op2, 0);
+      console.log("After client 2:", doc.content, "v" + doc.version);
+      console.log("Transformed op2:", JSON.stringify(result2.op));
+
+      // Should have both edits
+      assert.ok(doc.content.includes("world"));
+      assert.ok(doc.content.includes("!"));
+    });
+
+    it("should handle concurrent edits on different lines", () => {
+      const initialText = "hello\nworld";
+      const doc = new Document("test", initialText, 0, new Date());
+
+      // Client 1: types "123" at end of line 1 (position 5, after "hello")
+      const op1 = simpleDiff("hello\nworld", "hello123\nworld");
+      console.log("Client 1 op (add '123' at end of line 1):", JSON.stringify(op1));
+
+      // Client 2: types "abc" after "wo" on line 2 (position 8, after "hello\nwo")
+      const op2 = simpleDiff("hello\nworld", "hello\nwoabcrld");
+      console.log("Client 2 op (add 'abc' after 'wo'):", JSON.stringify(op2));
+
+      // Server receives client 1's op first
+      const result1 = doc.applyOp(op1, 0);
+      console.log("Server after client 1:", JSON.stringify(doc.content), "v" + doc.version);
+      assert.strictEqual(doc.content, "hello123\nworld");
+
+      // Server receives client 2's op (needs transformation against client 1's op)
+      const result2 = doc.applyOp(op2, 0);
+      console.log("Server after client 2:", JSON.stringify(doc.content), "v" + doc.version);
+      console.log("Transformed client 2 op:", JSON.stringify(result2.op));
+
+      // Final result should have both edits
+      assert.strictEqual(doc.content, "hello123\nwoabcrld");
+      console.log("✓ Final text is correct:", JSON.stringify(doc.content));
+    });
+  });
+});

--- a/src/server/ot.test.ts
+++ b/src/server/ot.test.ts
@@ -1,0 +1,63 @@
+import { Document } from "./document";
+import { TextOp } from "./ot";
+import assert from "assert";
+
+describe("Document OT", () => {
+  it("should apply operations in order", () => {
+    const doc = new Document("test", "hello", 0, new Date());
+
+    // Op 1: insert " world" at end
+    const op1: TextOp = [{ retain: 5 }, { insert: " world" }];
+    const res1 = doc.applyOp(op1, 0);
+
+    assert.strictEqual(doc.content, "hello world");
+    assert.strictEqual(doc.version, 1);
+    assert.strictEqual(res1.version, 1);
+    assert.deepStrictEqual(res1.op, op1);
+  });
+
+  it("should transform out-of-order operations", () => {
+    const doc = new Document("test", "hello", 0, new Date());
+
+    // Client A: insert " world" at end (base 0)
+    const opA: TextOp = [{ retain: 5 }, { insert: " world" }];
+    doc.applyOp(opA, 0); // doc becomes "hello world", v1
+
+    // Client B: insert "!" at end (base 0) - concurrent with A
+    const opB: TextOp = [{ retain: 5 }, { insert: "!" }];
+
+    // Apply opB (base 0) to doc (v1)
+    // Should transform opB against opA
+    const resB = doc.applyOp(opB, 0);
+
+    // Expected: "hello world!" (A's insert came first, B's insert pushed after? Or before?)
+    // Transform logic:
+    // opA: retain 5, insert " world"
+    // opB: retain 5, insert "!"
+    // Both insert at pos 5.
+    // Transform(opB, opA):
+    // opA inserts " world". opB must retain 6 (" world".length) to skip it?
+    // Wait, standard OT: if two inserts at same pos, one wins.
+    // My transform implementation:
+    // if c1 (opB) insert, emit insert.
+    // if c2 (opA) insert, emit retain.
+    // So opB comes first?
+    // Let's check transform implementation in ot.ts
+    // if c1.insert -> result.push(insert)
+    // if c2.insert -> result.push(retain)
+    // So opB (c1) is inserted BEFORE opA (c2).
+    // So result should be "hello! world"
+
+    assert.strictEqual(doc.content, "hello! world");
+    assert.strictEqual(doc.version, 2);
+  });
+
+  it("should handle applyTextUpdate for simple case", () => {
+    const doc = new Document("test", "hello", 0, new Date());
+
+    // Update to "hello world" (base 0) - straightforward append
+    doc.applyTextUpdate("hello world", 0);
+    assert.strictEqual(doc.content, "hello world");
+    assert.strictEqual(doc.version, 1);
+  });
+});

--- a/src/server/ot.ts
+++ b/src/server/ot.ts
@@ -1,0 +1,313 @@
+// Operational Transformation utilities for plain text operations
+
+export type TextOp = Array<
+  | { retain: number }
+  | { insert: string }
+  | { delete: number }
+>;
+
+/**
+ * Apply a TextOp to a string, returning the transformed string.
+ */
+export function apply(op: TextOp, text: string): string {
+  let result = "";
+  let pos = 0;
+
+  for (const component of op) {
+    if ("retain" in component) {
+      const n = component.retain;
+      if (pos + n > text.length) {
+        throw new Error(`Retain ${n} exceeds text length ${text.length} at position ${pos}`);
+      }
+      result += text.slice(pos, pos + n);
+      pos += n;
+    } else if ("insert" in component) {
+      result += component.insert;
+      // pos doesn't advance for inserts
+    } else if ("delete" in component) {
+      const n = component.delete;
+      if (pos + n > text.length) {
+        throw new Error(`Delete ${n} exceeds text length ${text.length} at position ${pos}`);
+      }
+      pos += n;
+      // don't add deleted text to result
+    }
+  }
+
+  if (pos !== text.length) {
+    throw new Error(`Op did not consume entire text. Position ${pos}, length ${text.length}`);
+  }
+
+  return result;
+}
+
+/**
+ * Transform op1 against op2, returning a new op that has the same effect
+ * as applying op1 then op2, but when applied after op2.
+ *
+ * This implements the standard OT transform for text operations.
+ * Uses a component-by-component approach without mutating inputs.
+ */
+export function transform(op1: TextOp, op2: TextOp): TextOp {
+  const result: TextOp = [];
+
+  // Create mutable copies of components with remaining counts
+  const comps1: Array<{ type: 'retain' | 'insert' | 'delete'; value: number | string; remaining: number }> = [];
+  for (const comp of op1) {
+    if ("retain" in comp) {
+      comps1.push({ type: 'retain', value: comp.retain, remaining: comp.retain });
+    } else if ("insert" in comp) {
+      comps1.push({ type: 'insert', value: comp.insert, remaining: comp.insert.length });
+    } else if ("delete" in comp) {
+      comps1.push({ type: 'delete', value: comp.delete, remaining: comp.delete });
+    }
+  }
+
+  const comps2: Array<{ type: 'retain' | 'insert' | 'delete'; value: number | string; remaining: number }> = [];
+  for (const comp of op2) {
+    if ("retain" in comp) {
+      comps2.push({ type: 'retain', value: comp.retain, remaining: comp.retain });
+    } else if ("insert" in comp) {
+      comps2.push({ type: 'insert', value: comp.insert, remaining: comp.insert.length });
+    } else if ("delete" in comp) {
+      comps2.push({ type: 'delete', value: comp.delete, remaining: comp.delete });
+    }
+  }
+
+  let i1 = 0, i2 = 0;
+
+  while (i1 < comps1.length || i2 < comps2.length) {
+    const c1 = i1 < comps1.length ? comps1[i1] : undefined;
+    const c2 = i2 < comps2.length ? comps2[i2] : undefined;
+
+    // 1. Handle c1 Insert
+    // If c1 is an insert, it always gets emitted immediately (we prioritize op1 coming first in tie-breaks)
+    if (c1 && c1.type === 'insert') {
+      result.push({ insert: c1.value as string });
+      i1++;
+      continue;
+    }
+
+    // 2. Handle c2 Insert
+    // If c2 is an insert, op1 must retain it (skip over the new text)
+    if (c2 && c2.type === 'insert') {
+      result.push({ retain: (c2.value as string).length });
+      i2++;
+      continue;
+    }
+
+    // 3. Handle End of Ops
+    if (!c1) {
+      // c1 is exhausted, but c2 might have more components.
+      // If c2 has inserts, they are handled above.
+      // If c2 has retains/deletes, we ignore them (op1 already covered the base doc).
+      // But to be safe and ensure progress if something is weird:
+      i2++;
+      continue;
+    }
+    if (!c2) {
+      // c2 is exhausted. c1 has leftovers.
+      // If c1 has inserts, handled above.
+      // If c1 has retains/deletes, append them.
+      if (c1.type === 'retain') {
+        result.push({ retain: c1.remaining });
+      } else if (c1.type === 'delete') {
+        result.push({ delete: c1.remaining });
+      }
+      i1++;
+      continue;
+    }
+
+    // 4. Both are Retain/Delete
+    if (c1.type === 'retain') {
+      if (c2.type === 'retain') {
+        const min = Math.min(c1.remaining, c2.remaining);
+        result.push({ retain: min });
+        c1.remaining -= min;
+        c2.remaining -= min;
+        if (c1.remaining === 0) i1++;
+        if (c2.remaining === 0) i2++;
+      } else { // c2.type === 'delete'
+        const min = Math.min(c1.remaining, c2.remaining);
+        // op2 deletes what op1 would retain - we skip that part (prune it)
+        // No output to result
+        c1.remaining -= min;
+        c2.remaining -= min;
+        if (c1.remaining === 0) i1++;
+        if (c2.remaining === 0) i2++;
+      }
+    } else { // c1.type === 'delete'
+      if (c2.type === 'retain') {
+        const min = Math.min(c1.remaining, c2.remaining);
+        // op1 deletes what op2 retains - we delete it
+        result.push({ delete: min });
+        c1.remaining -= min;
+        c2.remaining -= min;
+        if (c1.remaining === 0) i1++;
+        if (c2.remaining === 0) i2++;
+      } else { // c2.type === 'delete'
+        const min = Math.min(c1.remaining, c2.remaining);
+        // Both delete the same text - we only need to delete once (it's already gone)
+        // No output to result (op1's delete is redundant)
+        c1.remaining -= min;
+        c2.remaining -= min;
+        if (c1.remaining === 0) i1++;
+        if (c2.remaining === 0) i2++;
+      }
+    }
+  }
+
+  return result;
+}
+
+/**
+ * Transform a cursor position through an operation.
+ * Returns the new position after the operation is applied.
+ */
+export function transformPosition(pos: number, op: TextOp): number {
+  let result = pos;
+  let currentPos = 0;
+
+  for (const component of op) {
+    if ("retain" in component) {
+      const end = currentPos + component.retain;
+      if (pos <= end) {
+        // Position is within this retain, no change needed
+        return result;
+      }
+      currentPos = end;
+    } else if ("insert" in component) {
+      if (currentPos < pos) {
+        // Insert happens before our position, so position moves forward
+        result += component.insert.length;
+      }
+      // currentPos doesn't advance for inserts
+    } else if ("delete" in component) {
+      const end = currentPos + component.delete;
+      if (pos <= currentPos) {
+        // Delete happens before our position, no change
+      } else if (pos <= end) {
+        // Position is within deleted range, move it to start of delete
+        result = currentPos;
+        return result;
+      } else {
+        // Delete happens before position, move position back
+        result -= component.delete;
+      }
+      currentPos = end;
+    }
+  }
+
+  return result;
+}
+
+
+/**
+ * Simple optimistic diff: finds longest common prefix and suffix,
+ * assumes a single contiguous change in the middle.
+ */
+export function simpleDiff(oldText: string, newText: string): TextOp {
+  // Find longest common prefix
+  let prefixLen = 0;
+  const minLen = Math.min(oldText.length, newText.length);
+  while (prefixLen < minLen && oldText[prefixLen] === newText[prefixLen]) {
+    prefixLen++;
+  }
+
+  // Find longest common suffix
+  let suffixLen = 0;
+  while (
+    suffixLen < minLen - prefixLen &&
+    oldText[oldText.length - 1 - suffixLen] === newText[newText.length - 1 - suffixLen]
+  ) {
+    suffixLen++;
+  }
+
+  // Extract the changed middle parts
+  const oldMiddle = oldText.substring(prefixLen, oldText.length - suffixLen);
+  const newMiddle = newText.substring(prefixLen, newText.length - suffixLen);
+
+  // Build the operation
+  const op: TextOp = [];
+  if (prefixLen > 0) {
+    op.push({ retain: prefixLen });
+  }
+  if (oldMiddle.length > 0) {
+    op.push({ delete: oldMiddle.length });
+  }
+  if (newMiddle.length > 0) {
+    op.push({ insert: newMiddle });
+  }
+  if (suffixLen > 0) {
+    op.push({ retain: suffixLen });
+  }
+
+  // If no change, return a single retain
+  if (op.length === 0) {
+    return [{ retain: oldText.length }];
+  }
+
+  return op;
+}
+
+export interface DocState {
+  version: number;
+  content: string;
+}
+
+export interface ProcessResult {
+  newDocState: DocState;
+  opToBroadcast: TextOp;
+  appliedVersion: number;
+}
+
+/**
+ * Process a direct operation from a client.
+ * Transforms the op against the history of operations since baseVersion.
+ */
+export function processOperation(
+  docState: DocState,
+  op: TextOp,
+  baseVersion: number,
+  getOpAtVersion: (v: number) => TextOp | undefined
+): ProcessResult {
+  // Transform incoming op from baseVersion -> current version
+  let transformedOp = op;
+  for (let v = baseVersion; v < docState.version; v++) {
+    const remote = getOpAtVersion(v + 1);
+    if (remote) {
+      transformedOp = transform(transformedOp, remote);
+    }
+  }
+
+  // Apply to document
+  const newContent = apply(transformedOp, docState.content);
+  const newVersion = docState.version + 1;
+
+  return {
+    newDocState: {
+      version: newVersion,
+      content: newContent,
+    },
+    opToBroadcast: transformedOp,
+    appliedVersion: newVersion,
+  };
+}
+
+/**
+ * Process a full text update from a client.
+ * Diffs the oldText (base) and newText to create an op, then transforms it.
+ */
+export function processTextUpdate(
+  docState: DocState,
+  oldText: string,
+  newText: string,
+  baseVersion: number,
+  getOpAtVersion: (v: number) => TextOp | undefined
+): ProcessResult {
+  // Compute diff from oldText to newText
+  const op = simpleDiff(oldText, newText);
+
+  // Use processOperation to handle the transformation and application
+  return processOperation(docState, op, baseVersion, getOpAtVersion);
+}


### PR DESCRIPTION
Converts the last write wins approach to an operation transform approach. Here's a really cool explainer app: https://operational-transformation.github.io

Rough overview:
- Server maintains a log of operations, client maintains a log of pending operations
- Clients calculate a (simple contiguous) diff of their edits, convert them to retain/insert/delete operations, send them to the server and place them in the pending operations log
- Server applies operations in the order it receives them
  - If an operation is applied to a base version older than the current, it rebases the operation using OT (replaying the op log)
  - It then broadcasts the resulting operation (along with its unique id) to all clients
- Clients listen for operations
  - If they recognize their own operation, they remove it from the pending log, and apply it to their local text version
  - If it is another client's operation, they update their local text to this version, and rebase all the pending operations to this version

Needs more testing, but seems to work locally with two tabs open. Haven't tried anything intensively real-time yet.